### PR TITLE
feat: capture output and overide env variables

### DIFF
--- a/scripts/build-repos.py
+++ b/scripts/build-repos.py
@@ -36,7 +36,7 @@ class PixiBuildError(Exception):
 
 
 def run_command(
-    cmd: list[str], cwd: Path | None = None, capture_output: bool = False
+    cmd: list[str], cwd: Path | None = None, capture_output: bool = True
 ) -> tuple[int, str, str]:
     """Run a command and return exit code, stdout, and stderr."""
     result = subprocess.run(cmd, cwd=cwd, capture_output=capture_output, text=True)

--- a/scripts/build-repos.py
+++ b/scripts/build-repos.py
@@ -35,9 +35,11 @@ class PixiBuildError(Exception):
     pass
 
 
-def run_command(cmd: list[str], cwd: Path | None = None) -> tuple[int, str, str]:
+def run_command(
+    cmd: list[str], cwd: Path | None = None, capture_output: bool = False
+) -> tuple[int, str, str]:
     """Run a command and return exit code, stdout, and stderr."""
-    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    result = subprocess.run(cmd, cwd=cwd, capture_output=capture_output, text=True)
     return result.returncode, result.stdout, result.stderr
 
 
@@ -120,7 +122,7 @@ def main() -> None:
     # Load environment variables from .env file
     env_file = Path(__file__).parent.parent / ".env"
     if env_file.exists():
-        load_dotenv(env_file)
+        load_dotenv(env_file, override=True)
         print(f"✅ Loaded environment variables from {env_file}")
     else:
         print(f"⚠️  No .env file found at {env_file}")

--- a/tests/integration_python/conftest.py
+++ b/tests/integration_python/conftest.py
@@ -79,7 +79,7 @@ def simple_workspace(tmp_pixi_workspace: Path, request: pytest.FixtureRequest) -
 
 @pytest.fixture(scope="session", autouse=True)
 def load_dotenv() -> None:
-    dotenv.load_dotenv()
+    dotenv.load_dotenv(override=True)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -122,7 +122,7 @@ def pixi() -> Path:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def build_backends(load_dotenv: None) -> None:
+def build_backends(_load_dotenv: None) -> None:
     """
     Sets up build backend environment variables for testing.
 

--- a/tests/integration_python/conftest.py
+++ b/tests/integration_python/conftest.py
@@ -122,7 +122,7 @@ def pixi() -> Path:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def build_backends(_load_dotenv: None) -> None:
+def build_backends(load_dotenv: None) -> None:
     """
     Sets up build backend environment variables for testing.
 

--- a/tests/integration_python/test_backends.py
+++ b/tests/integration_python/test_backends.py
@@ -32,7 +32,7 @@ def test_pixi_minimal_backend(pixi_project: Path, pixi: Path, tmp_pixi_workspace
 
     # Install the environment
     verify_cli_command(
-        [pixi, "run", "--manifest-path", manifest, "start"],
+        [pixi, "run", "--locked", "--manifest-path", manifest, "start"],
         env=env,
         stdout_contains="Build backend works",
     )

--- a/tests/integration_python/test_backends.py
+++ b/tests/integration_python/test_backends.py
@@ -32,7 +32,7 @@ def test_pixi_minimal_backend(pixi_project: Path, pixi: Path, tmp_pixi_workspace
 
     # Install the environment
     verify_cli_command(
-        [pixi, "run", "--locked", "--manifest-path", manifest, "start"],
+        [pixi, "run", "--manifest-path", manifest, "start"],
         env=env,
         stdout_contains="Build backend works",
     )


### PR DESCRIPTION
## Overview

I would like to improve 2 things:

1) After we load direnv and set it in main.py, changing the .env doesn't have anymore effect
2) We want to show the progress of cargo build for example in `build-repos`