### PR TITLE
fix: add `package.name` to all examples

### DIFF
--- a/tests/data/pixi_build/multi-output/recipe/pixi.toml
+++ b/tests/data/pixi_build/multi-output/recipe/pixi.toml
@@ -1,2 +1,6 @@
+[package]
+name = "multi-output"
+version = "0.1.0"
+
 [package.build]
 backend = { name = "pixi-build-rattler-build", version = "*" }

--- a/tests/data/pixi_build/rattler-build-backend/smokey/pixi.toml
+++ b/tests/data/pixi_build/rattler-build-backend/smokey/pixi.toml
@@ -1,13 +1,15 @@
 [project]
 channels = ["conda-forge"]
 description = "Add a short description here"
-name = "smokey-build"
 platforms = ["osx-arm64", "linux-64", "osx-64", "win-64"]
 preview = ["pixi-build"]
-version = "0.1.0"
 
 [dependencies]
 smokey = { path = "." }
+
+[package]
+name = "smokey-build"
+version = "0.1.0"
 
 [package.build]
 backend = { name = "pixi-build-rattler-build", version = "0.1.*" }

--- a/tests/data/pixi_build/rattler-build-backend/smokey2/pixi.toml
+++ b/tests/data/pixi_build/rattler-build-backend/smokey2/pixi.toml
@@ -1,13 +1,15 @@
 [project]
 channels = ["conda-forge"]
 description = "Add a short description here"
-name = "smokey2-build"
 platforms = ["osx-arm64", "linux-64", "osx-64", "win-64"]
 preview = ["pixi-build"]
-version = "0.1.0"
 
 [dependencies]
 smokey2 = { path = "." }
+
+[package]
+name = "smokey2-build"
+version = "0.1.0"
 
 [package.build]
 backend = { name = "pixi-build-rattler-build", version = "0.1.*" }

--- a/tests/data/pixi_build/rattler-build-backend/smokey2/pixi.toml
+++ b/tests/data/pixi_build/rattler-build-backend/smokey2/pixi.toml
@@ -8,7 +8,7 @@ preview = ["pixi-build"]
 smokey2 = { path = "." }
 
 [package]
-name = "smokey2-build"
+name = "smokey2"
 version = "0.1.0"
 
 [package.build]

--- a/tests/integration_python/conftest.py
+++ b/tests/integration_python/conftest.py
@@ -58,7 +58,7 @@ def simple_workspace(tmp_pixi_workspace: Path, request: pytest.FixtureRequest) -
             "build": {
                 "backend": {"name": "pixi-build-rattler-build", "version": "0.1.*"},
                 "configuration": {"debug-dir": str(debug_dir)},
-            }
+            },
         },
     }
 

--- a/tests/integration_python/conftest.py
+++ b/tests/integration_python/conftest.py
@@ -47,14 +47,14 @@ def simple_workspace(tmp_pixi_workspace: Path, request: pytest.FixtureRequest) -
             ],
             "preview": ["pixi-build"],
             "platforms": [CURRENT_PLATFORM],
-            "name": name,
-            "version": "1.0.0",
         },
         "dependencies": {name: {"path": package_rel_dir}},
     }
 
     package_manifest = {
         "package": {
+            "name": name,
+            "version": "1.0.0",
             "build": {
                 "backend": {"name": "pixi-build-rattler-build", "version": "0.1.*"},
                 "configuration": {"debug-dir": str(debug_dir)},


### PR DESCRIPTION
In preperation of https://github.com/prefix-dev/pixi/pull/4078 Im adding a name to all packages in this project. This should be backwards compatible with older pixi versions as well so I expect all tests to succeed.