### PR TITLE
tweak example package name

### DIFF
--- a/tests/data/pixi_build/rattler-build-backend/smokey/pixi.toml
+++ b/tests/data/pixi_build/rattler-build-backend/smokey/pixi.toml
@@ -8,7 +8,7 @@ preview = ["pixi-build"]
 smokey = { path = "." }
 
 [package]
-name = "smokey-build"
+name = "smokey"
 version = "0.1.0"
 
 [package.build]


### PR DESCRIPTION
I called the workspace name `smokey-build` to separate it from the package, but now that we are using `package.name` it makes sense to just say `smokey`.

small follow-up to gh-14