### PR TITLE
fix: no wrap instead of no graphics

### DIFF
--- a/tests/integration_python/common.py
+++ b/tests/integration_python/common.py
@@ -81,8 +81,8 @@ def verify_cli_command(
 ) -> Output:
     base_env = {} if reset_env else dict(os.environ)
     complete_env = base_env if env is None else base_env | env
-    # Set `NO_GRAPHICS` to avoid to have miette splitting up lines
-    complete_env |= {"NO_GRAPHICS": "1"}
+    # Set `PIXI_NO_WRAP` to avoid to have miette wrapping lines
+    complete_env |= {"PIXI_NO_WRAP": "1"}
 
     process = subprocess.run(
         command,


### PR DESCRIPTION
Use `PIXI_NO_WRAP` instead of `NO_GRAPHICS` to pretty print errors.