### PR TITLE
fix: move author to package

### DIFF
--- a/tests/data/pixi_build/minimal-backend-workspaces/pixi-build-rust/pixi.toml
+++ b/tests/data/pixi_build/minimal-backend-workspaces/pixi-build-rust/pixi.toml
@@ -1,5 +1,4 @@
 [workspace]
-authors = ["Julian Hofer <julianhofer@gnome.org>"]
 channels = [
   "https://prefix.dev/pixi-build-backends",
   "https://prefix.dev/conda-forge",
@@ -18,6 +17,7 @@ start = "simple-app"
 [package]
 name = "simple-app"
 version = "0.1.0"
+authors = ["Julian Hofer <julianhofer@gnome.org>"]
 
 [package.build]
 backend = { name = "pixi-build-rust", version = "*" }


### PR DESCRIPTION
When [adding explicit `{ workspace = true }` behavior](https://github.com/prefix-dev/pixi/pull/4078), the lock-file of the rust-minimal test would fail. This was because the workspace had an author and the package did not. Because fields are no longer automatically inherited from the workspace the author field was missing from the package. This caused the lock-file to be out of date.

This PR fixes this by moving the author of the package to the package itself.