### PR TITLE
test: add verbose flag to see build output

### DIFF
--- a/tests/integration_python/test_backends.py
+++ b/tests/integration_python/test_backends.py
@@ -29,6 +29,6 @@ def test_pixi_minimal_backend(pixi_project: Path, pixi: Path, tmp_pixi_workspace
 
     # Install the environment
     verify_cli_command(
-        [pixi, "run", "--locked", "--manifest-path", manifest, "start"],
+        [pixi, "run", "-v", "--locked", "--manifest-path", manifest, "start"],
         stdout_contains="Build backend works",
     )

--- a/tests/integration_python/test_build.py
+++ b/tests/integration_python/test_build.py
@@ -16,6 +16,7 @@ def test_build_conda_package(
         [
             pixi,
             "build",
+            "-v",
             "--manifest-path",
             simple_workspace.package_dir,
             "--output-dir",
@@ -53,6 +54,7 @@ def test_build_conda_package_variants(
         [
             pixi,
             "build",
+            "-v",
             "--manifest-path",
             simple_workspace.package_dir,
             "--output-dir",
@@ -78,6 +80,7 @@ def test_no_change_should_be_fully_cached(pixi: Path, simple_workspace: Workspac
         [
             pixi,
             "install",
+            "-v",
             "--manifest-path",
             simple_workspace.workspace_dir,
         ]
@@ -97,6 +100,7 @@ def test_no_change_should_be_fully_cached(pixi: Path, simple_workspace: Workspac
         [
             pixi,
             "install",
+            "-v",
             "--manifest-path",
             simple_workspace.workspace_dir,
         ]
@@ -113,6 +117,7 @@ def test_source_change_trigger_rebuild(pixi: Path, simple_workspace: Workspace) 
         [
             pixi,
             "install",
+            "-v",
             "--manifest-path",
             simple_workspace.workspace_dir,
         ],
@@ -132,6 +137,7 @@ def test_source_change_trigger_rebuild(pixi: Path, simple_workspace: Workspace) 
         [
             pixi,
             "install",
+            "-v",
             "--manifest-path",
             simple_workspace.workspace_dir,
         ],
@@ -149,6 +155,7 @@ def test_project_model_change_trigger_rebuild(
         [
             pixi,
             "install",
+            "-v",
             "--manifest-path",
             simple_workspace.workspace_dir,
         ],
@@ -170,6 +177,7 @@ def test_project_model_change_trigger_rebuild(
         [
             pixi,
             "install",
+            "-v",
             "--manifest-path",
             simple_workspace.workspace_dir,
         ],
@@ -196,6 +204,7 @@ def test_editable_pyproject(pixi: Path, build_data: Path, tmp_pixi_workspace: Pa
         [
             pixi,
             "install",
+            "-v",
             "--manifest-path",
             manifest_path,
         ],
@@ -206,6 +215,7 @@ def test_editable_pyproject(pixi: Path, build_data: Path, tmp_pixi_workspace: Pa
         [
             pixi,
             "run",
+            "-v",
             "--manifest-path",
             manifest_path,
             "check-editable",
@@ -235,6 +245,7 @@ def test_non_editable_pyproject(pixi: Path, build_data: Path, tmp_pixi_workspace
         [
             pixi,
             "install",
+            "-v",
             "--manifest-path",
             manifest_path,
         ],
@@ -246,6 +257,7 @@ def test_non_editable_pyproject(pixi: Path, build_data: Path, tmp_pixi_workspace
         [
             pixi,
             "run",
+            "-v",
             "--manifest-path",
             manifest_path,
             "check-editable",
@@ -269,7 +281,7 @@ def test_build_using_rattler_build_backend(
 
     # Running pixi build should build the recipe.yaml
     verify_cli_command(
-        [pixi, "build", "--manifest-path", manifest_path, "--output-dir", tmp_pixi_workspace],
+        [pixi, "build", "-v", "--manifest-path", manifest_path, "--output-dir", tmp_pixi_workspace],
     )
 
     # really make sure that conda package was built
@@ -289,6 +301,7 @@ def test_error_manifest_deps(pixi: Path, build_data: Path, tmp_pixi_workspace: P
         [
             pixi,
             "install",
+            "-v",
             "--manifest-path",
             manifest_path,
         ],
@@ -309,6 +322,7 @@ def test_error_manifest_deps_no_default(
         [
             pixi,
             "install",
+            "-v",
             "--manifest-path",
             manifest_path,
         ],
@@ -335,6 +349,7 @@ def test_recursive_source_run_dependencies(
         [
             pixi,
             "install",
+            "-v",
             "--manifest-path",
             manifest_path,
         ],
@@ -346,6 +361,7 @@ def test_recursive_source_run_dependencies(
         [
             pixi,
             "run",
+            "-v",
             "--manifest-path",
             manifest_path,
             "package-b",

--- a/tests/integration_python/test_examples.py
+++ b/tests/integration_python/test_examples.py
@@ -32,4 +32,4 @@ def test_pixi_install_examples(pixi_project: Path, pixi: Path, tmp_pixi_workspac
     manifest = get_manifest(tmp_pixi_workspace)
 
     # Install the environment
-    verify_cli_command([pixi, "install", "--locked", "--manifest-path", manifest])
+    verify_cli_command([pixi, "install", "-v", "--locked", "--manifest-path", manifest])

--- a/tests/integration_python/test_git.py
+++ b/tests/integration_python/test_git.py
@@ -50,7 +50,7 @@ def test_build_git_source_deps(pixi: Path, tmp_pixi_workspace: Path, build_data:
     )
 
     # build it
-    verify_cli_command([pixi, "install", "--manifest-path", minimal_workspace / "pixi.toml"])
+    verify_cli_command([pixi, "install", "-v", "--manifest-path", minimal_workspace / "pixi.toml"])
 
     # verify that we indeed recorded the git url with it's commit
     pixi_lock_file = minimal_workspace / "pixi.lock"
@@ -73,7 +73,7 @@ def test_build_git_source_deps(pixi: Path, tmp_pixi_workspace: Path, build_data:
     ).stdout.strip()
 
     # build it again
-    verify_cli_command([pixi, "update", "--manifest-path", minimal_workspace / "pixi.toml"])
+    verify_cli_command([pixi, "update", "-v", "--manifest-path", minimal_workspace / "pixi.toml"])
 
     # verify that we indeed recorded the git url with it's commit
     pixi_lock_file = minimal_workspace / "pixi.lock"

--- a/tests/integration_python/test_multi_output.py
+++ b/tests/integration_python/test_multi_output.py
@@ -12,7 +12,15 @@ def test_build(pixi: Path, build_data: Path, tmp_pixi_workspace: Path) -> None:
     package_manifest = tmp_pixi_workspace.joinpath("recipe", "pixi.toml")
 
     verify_cli_command(
-        [pixi, "build", "--manifest-path", package_manifest, "--output-dir", tmp_pixi_workspace],
+        [
+            pixi,
+            "build",
+            "-v",
+            "--manifest-path",
+            package_manifest,
+            "--output-dir",
+            tmp_pixi_workspace,
+        ],
     )
 
     # Ensure that exactly three conda packages have been built
@@ -27,10 +35,10 @@ def test_install(pixi: Path, build_data: Path, tmp_pixi_workspace: Path) -> None
     shutil.copytree(test_data, tmp_pixi_workspace, dirs_exist_ok=True)
 
     # Run `install` should work and create a lock file
-    verify_cli_command([pixi, "install", "--manifest-path", tmp_pixi_workspace])
+    verify_cli_command([pixi, "install", "-v", "--manifest-path", tmp_pixi_workspace])
 
     # Running `install` again require a lock file update
-    verify_cli_command([pixi, "install", "--locked", "--manifest-path", tmp_pixi_workspace])
+    verify_cli_command([pixi, "install", "-v", "--locked", "--manifest-path", tmp_pixi_workspace])
 
 
 def test_available_packages(pixi: Path, build_data: Path, tmp_pixi_workspace: Path) -> None:
@@ -41,17 +49,17 @@ def test_available_packages(pixi: Path, build_data: Path, tmp_pixi_workspace: Pa
 
     # foobar-desktop is a direct dependency, so it should be properly installed
     verify_cli_command(
-        [pixi, "run", "--manifest-path", tmp_pixi_workspace, "foobar-desktop"],
+        [pixi, "run", "-v", "--manifest-path", tmp_pixi_workspace, "foobar-desktop"],
         stdout_contains="Hello from foobar-desktop",
     )
     # foobar is a dependency of foobar-desktop, so it should be there as well
     verify_cli_command(
-        [pixi, "run", "--manifest-path", tmp_pixi_workspace, "foobar"],
+        [pixi, "run", "-v", "--manifest-path", tmp_pixi_workspace, "foobar"],
         stdout_contains="Hello from foobar",
     )
     # bizbar is a output of the recipe, but we don't request it
     # So it shouldn't be part of the environment
     verify_cli_command(
-        [pixi, "run", "--manifest-path", tmp_pixi_workspace, "bizbar"],
+        [pixi, "run", "-v", "--manifest-path", tmp_pixi_workspace, "bizbar"],
         expected_exit_code=ExitCode.COMMAND_NOT_FOUND,
     )


### PR DESCRIPTION
Adds the `-v` flag to pixi commands. Pixi hides the build output by default. This brings it back.