### PR TITLE
chore: `-m` for `git tag`

### DIFF
--- a/tests/integration_python/test_git.py
+++ b/tests/integration_python/test_git.py
@@ -242,7 +242,7 @@ def test_build_git_source_deps_from_tag(
 
     verify_cli_command(["git", "add", "."], cwd=target_git_dir)
     verify_cli_command(["git", "commit", "-m", "initial commit"], cwd=target_git_dir)
-    verify_cli_command(["git", "tag", "v1.0.0"], cwd=target_git_dir)
+    verify_cli_command(["git", "tag", "v1.0.0", "-m 'my version 1.0.0"], cwd=target_git_dir)
 
     # extract exact commit hash that we will use
     commit_hash = verify_cli_command(


### PR DESCRIPTION
locally for me this avoids

```
command: ['git', 'tag', 'v1.0.0'], stdout: , stderr: error: there was a problem with the editor 'nano'
Please supply the message using either -m or -F option.
```

not sure why that shows as `nano` works fine in my shell, but this fix seems harmless enough to not bother investigating further IMO!