### PR TITLE
Make pixi build testsuite more flexible

### DIFF
--- a/.env.ci.example
+++ b/.env.ci.example
@@ -1,0 +1,11 @@
+# CI Environment Override Configuration
+# Copy this file to .env.ci to override repository/branch settings for testing PR combinations
+# WARNING: Never commit .env.ci to main branch!
+
+# Pixi repository override settings
+PIXI_CI_REPO_NAME="prefix-dev/pixi"
+PIXI_CI_REPO_BRANCH="feature-branch"
+
+# Pixi build backends repository override settings  
+BUILD_BACKENDS_CI_REPO_NAME="prefix-dev/pixi-build-backends"
+BUILD_BACKENDS_CI_REPO_BRANCH="feature-branch"

--- a/.github/workflows/prevent-branch-override-merge.yml
+++ b/.github/workflows/prevent-branch-override-merge.yml
@@ -1,0 +1,17 @@
+name: Prevent Branch Override Merge
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-branch-override:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@main
+
+      - name: Check for branch override files
+        run: pixi run check-branch-override

--- a/pixi.toml
+++ b/pixi.toml
@@ -40,6 +40,7 @@ test-specific-test = { cmd = "pytest -k '{{ test_substring }}'", args = [
 # Update one test channel by passing on value of `mappings.toml`
 # e.g. "multiple_versions_channel_1"
 build-repos = { cmd = "python scripts/build-repos.py", description = "Update and build external repositories (PIXI and BUILD_BACKENDS)" }
+check-branch-override = { cmd = "python scripts/check-branch-override.py", description = "Check for branch override files that shouldn't be merged" }
 download-artifacts = { cmd = "python scripts/download-artifacts.py" }
 update-lockfiles = { cmd = "python scripts/update-lockfiles.py {{ folder }}", args = [
   { "arg" = "folder", "default" = "" },

--- a/scripts/check-branch-override.py
+++ b/scripts/check-branch-override.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+Script to check for CI override files that shouldn't be merged to main.
+
+This script ensures that .env.ci files used for testing PR combinations
+don't accidentally get merged to the main branch.
+"""
+
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    """Check if CI override files exist and exit with error if found."""
+    repo_root = Path(__file__).parent.parent
+    override_file = repo_root / ".env.ci"
+
+    if override_file.exists():
+        print("❌ ERROR: .env.ci file detected")
+        print("This file is used for testing PR combinations and should not be merged to main")
+        print("Please remove .env.ci from your branch")
+        sys.exit(1)
+    else:
+        print("✅ No CI override files detected - safe to merge")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add file `.env.ci` that points to a different repo and branch
- That way you can make sure that the combination of a testsuite PR and pixi/pixi-build-backend PR lead to a green CI
- Add CI job that makes sure that fails if the file is there (to make sure it doesn't get merged by accident)