### PR TITLE
fix: verbosity changed to output logs 

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,2 +1,0 @@
-# Test with specific PR from pixi repository
-PIXI_PR_NUMBER="4495"


### PR DESCRIPTION
depends on: https://github.com/prefix-dev/pixi/pull/4495