### PR TITLE
feat: allow setting prs for local testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,13 +35,8 @@ jobs:
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
 
-      - name: Download pixi artifacts
-        run: pixi run download-artifacts pixi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download pixi-build-backends artifacts
-        run: pixi run download-artifacts pixi-build-backends
+      - name: Download artifacts
+        run: pixi run download-artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -74,15 +69,9 @@ jobs:
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
 
-      - name: Download pixi artifacts
+      - name: Download artifacts
         working-directory: ${{ env.PIXI_WORKSPACE }}
-        run: pixi run download-artifacts pixi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download pixi-build-backends artifacts
-        working-directory: ${{ env.PIXI_WORKSPACE }}
-        run: pixi run download-artifacts pixi-build-backends
+        run: pixi run download-artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -106,13 +95,8 @@ jobs:
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
 
-      - name: Download pixi artifacts
-        run: pixi run download-artifacts pixi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download pixi-build-backends artifacts
-        run: pixi run download-artifacts pixi-build-backends
+      - name: Download artifacts
+        run: pixi run download-artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,23 @@ This repo contains the testsuite that is used by both [Pixi] CI and [pixi-build-
 
 ## Local development
 
-First make sure that you have both the [Pixi] and [pixi-build-backends] repositories checked out locally.
+The tests can use the pre-built binaries produced by the Pixi and pixi-build-backends CI workflows. Download the latest artifacts for your platform:
 
-Then, create a `.env` file at the repository root with the paths to your checked out repositories filled in.
+```shell
+pixi run download-artifacts
+```
+
+The binaries are stored in `artifacts/`, alongside a `download-metadata.json` file that records which branch or PR each artifact originated from. When running locally the script will reuse the active `gh auth` session; if `gh` is unavailable, set `GITHUB_TOKEN` or pass `--token`. Use `--repo pixi` or `--repo pixi-build-backends` to fetch artifacts for a single project.
+
+With the artifacts in place you can run the fast subset of the tests (or any other Pixi task):
+
+```shell
+pixi run test
+```
+
+### Using local builds instead of artifacts
+
+If you prefer to use local checkouts, create a `.env` file with the paths to your repositories:
 
 ```shell
 PIXI_REPO="/path/to/pixi-repository"
@@ -17,37 +31,28 @@ PIXI_BIN_DIR="${PIXI_REPO}/target/pixi/release"
 BUILD_BACKENDS_BIN_DIR="${BUILD_BACKENDS_REPO}/target/pixi/release"
 ```
 
-You can build the executables by running the following Pixi task.
-It will also make sure that your repositories are up-to-date:
+Then build the binaries with:
 
 ```shell
 pixi run build-repos
 ```
 
-Finally, you can run the fast subset of the tests with the following task.
-Also, check out the other Pixi tasks to run more tests on your local machine:
-
-```shell
-pixi run test
-```
-
-## Testing PR combinations in CI
+## Testing PR combinations
 
 To test a combination of PRs from this testsuite with PRs from [Pixi] or [pixi-build-backends]:
 
-1. Create a `.env.ci` file with PR numbers:
+1. Create a `.env.ci` or modify your local `.env` file with PR numbers:
    ```shell
    # Test with specific PR from pixi repository
    PIXI_PR_NUMBER="123"
-   
-   # Test with specific PR from pixi-build-backends repository  
+
+   # Test with specific PR from pixi-build-backends repository
    BUILD_BACKENDS_PR_NUMBER="456"
    ```
-2. The CI will download artifacts from these PRs instead of main branch
+2. `pixi run download-artifacts` (locally or in CI) will download artifacts from these PRs instead of main
 3. **Important**: Remove `.env.ci` before merging to main (CI will prevent merge if present)
 
 This allows you to test how your testsuite changes work with specific PRs from the other repositories.
-
 
 [Pixi]: https://github.com/prefix-dev/pixi
 [pixi-build-backends]: https://github.com/prefix-dev/pixi-build-backends

--- a/examples/build-recipe/pixi.lock
+++ b/examples/build-recipe/pixi.lock
@@ -5,15 +5,15 @@ environments:
     - url: https://prefix.dev/conda-forge/
     packages:
       osx-arm64:
-      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.7.14-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.50.3-h4237e3c_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.50.4-h4237e3c_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.5.1-h81ee809_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.5.3-h5503f6c_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.12.11-hc22306f_0_cpython.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
@@ -29,14 +29,14 @@ packages:
     hash: dc7c9f16d3adb03a761d4195d8fcdc962c2244bc45e508f8ca183afa6cb808d1
     globs:
     - recipe.yaml
-- conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.7.14-hbd8a1cb_0.conda
-  sha256: 29defbd83c7829788358678ec996adeee252fa4d4274b7cd386c1ed73d2b201e
-  md5: d16c90324aef024877d8713c0b7fea5b
+- conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
+  sha256: 837b795a2bb39b75694ba910c13c15fa4998d4bb2a622c214a6a5174b2ae53d1
+  md5: 74784ee3d225fc3dca89edb635b4e5cc
   depends:
   - __unix
   license: ISC
-  size: 155658
-  timestamp: 1752482350666
+  size: 154402
+  timestamp: 1754210968730
 - conda: https://prefix.dev/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
   sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
   md5: 5eb22c1d7b3fc4abb50d92d621583137
@@ -76,16 +76,16 @@ packages:
   license: 0BSD
   size: 92286
   timestamp: 1749230283517
-- conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.50.3-h4237e3c_1.conda
-  sha256: 248ba9622ee91c3ae1266f7b69143adf5031e1f2d94b6d02423e192e47531697
-  md5: 6d034f4604ac104a1256204af7d1a534
+- conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.50.4-h4237e3c_0.conda
+  sha256: 802ebe62e6bc59fc26b26276b793e0542cfff2d03c086440aeaf72fb8bbcec44
+  md5: 1dcb0468f5146e38fae99aef9656034b
   depends:
   - __osx >=11.0
   - icu >=75.1,<76.0a0
   - libzlib >=1.3.1,<2.0a0
   license: blessing
-  size: 902818
-  timestamp: 1753262833682
+  size: 902645
+  timestamp: 1753948599139
 - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
   sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
   md5: 369964e85dc26bfe78f41399b366c435
@@ -105,16 +105,16 @@ packages:
   license: X11 AND BSD-3-Clause
   size: 797030
   timestamp: 1738196177597
-- conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.5.1-h81ee809_0.conda
-  sha256: f94fde0f096fa79794c8aa0a2665630bbf9026cc6438e8253f6555fc7281e5a8
-  md5: a8ac77e7c7e58d43fa34d60bd4361062
+- conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.5.3-h5503f6c_0.conda
+  sha256: c547508f11f214125fe5fc66da3d5a5dad6a9204315ee880b5ba65cdb32b6572
+  md5: 161d97c4c31b7851617119e6f851927f
   depends:
   - __osx >=11.0
   - ca-certificates
   license: Apache-2.0
   license_family: Apache
-  size: 3071649
-  timestamp: 1751390309393
+  size: 3069340
+  timestamp: 1758040933817
 - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.12.11-hc22306f_0_cpython.conda
   sha256: cde8b944c2dc378a5afbc48028d0843583fd215493d5885a80f1b41de085552f
   md5: 9207ebad7cfbe2a4af0702c92fd031c4

--- a/scripts/download-artifacts.py
+++ b/scripts/download-artifacts.py
@@ -429,9 +429,7 @@ def main() -> None:
     output_dir = Path("artifacts")
 
     # Get GitHub token from argument or environment
-    github_token = args.token or os.getenv("GITHUB_TOKEN")
-    if not github_token:
-        github_token = get_token_from_gh()
+    github_token = args.token or os.getenv("GITHUB_TOKEN") or get_token_from_gh()
     if not github_token:
         console.print("[red][ERROR] No GitHub token provided")
         console.print(

--- a/scripts/download-artifacts.py
+++ b/scripts/download-artifacts.py
@@ -214,8 +214,7 @@ def get_token_from_gh() -> str | None:
         )
     except subprocess.CalledProcessError as exc:
         console.print(
-            "[yellow]Failed to obtain token via GitHub CLI. "
-            f"Return code: {exc.returncode}"
+            f"[yellow]Failed to obtain token via GitHub CLI. Return code: {exc.returncode}"
         )
         return None
 

--- a/tests/integration_python/conftest.py
+++ b/tests/integration_python/conftest.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 from pathlib import Path
@@ -5,7 +6,7 @@ from pathlib import Path
 import dotenv
 import pytest
 
-from .common import CURRENT_PLATFORM, Workspace, exec_extension
+from .common import CURRENT_PLATFORM, Workspace, exec_extension, repo_root
 
 
 @pytest.fixture
@@ -77,9 +78,70 @@ def simple_workspace(tmp_pixi_workspace: Path, request: pytest.FixtureRequest) -
     )
 
 
+def _metadata_path() -> Path:
+    return repo_root().joinpath("artifacts", "download-metadata.json")
+
+
+def _load_artifact_metadata() -> dict[str, object]:
+    metadata_file = _metadata_path()
+    if not metadata_file.exists():
+        return {}
+
+    try:
+        return json.loads(metadata_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+        raise RuntimeError(
+            f"Artifact metadata file at {metadata_file} is not valid JSON. Re-run 'pixi run download-artifacts'."
+        ) from exc
+
+
+def _validate_artifact_sources() -> None:
+    metadata = _load_artifact_metadata()
+    if not metadata:
+        return
+
+    checks = [
+        ("prefix-dev/pixi", "PIXI_PR_NUMBER"),
+        ("prefix-dev/pixi-build-backends", "BUILD_BACKENDS_PR_NUMBER"),
+    ]
+
+    for repo, env_var in checks:
+        entry = metadata.get(repo)
+        if not isinstance(entry, dict):
+            continue
+
+        source = entry.get("source")
+        env_value = os.getenv(env_var, "").strip()
+
+        if source == "pr":
+            pr_number = str(entry.get("pr_number", "")).strip()
+            if not pr_number:
+                raise RuntimeError(
+                    f"Artifact metadata for {repo} is missing a pull request number. Re-run 'pixi run download-artifacts'."
+                )
+            if not env_value:
+                raise RuntimeError(
+                    f"Artifacts for {repo} originate from PR #{pr_number}, but {env_var} is not set. "
+                    "Set the environment variable or re-download the correct artifacts."
+                )
+            if env_value != pr_number:
+                raise RuntimeError(
+                    f"Artifacts for {repo} originate from PR #{pr_number}, but {env_var}={env_value!r}. "
+                    "Update your environment or refresh the artifacts."
+                )
+        elif source == "branch":
+            if env_value:
+                branch = entry.get("branch", "main")
+                raise RuntimeError(
+                    f"Artifacts for {repo} originate from branch '{branch}', but {env_var}={env_value!r} is set. "
+                    "Unset the environment variable or download the matching PR artifacts."
+                )
+
+
 @pytest.fixture(scope="session", autouse=True)
 def load_dotenv() -> None:
     dotenv.load_dotenv(override=True)
+    _validate_artifact_sources()
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -97,17 +159,36 @@ def pixi() -> Path:
     Returns the path to the Pixi executable.
 
     Uses the PIXI_BIN_DIR environment variable to locate the Pixi directory.
-    Locally, this is typically done via the .env file.
+    Falls back to binaries downloaded into the artifacts directory.
     """
     pixi_bin_dir = os.getenv("PIXI_BIN_DIR")
-    if not pixi_bin_dir:
+
+    if pixi_bin_dir:
+        pixi_bin_path = Path(pixi_bin_dir)
+    else:
+        project_root = repo_root()
+        candidates = [
+            project_root / "artifacts",
+            project_root / "artifacts" / "pixi",
+        ]
+        pixi_bin_path = None
+        for candidate in candidates:
+            executable_candidate = candidate / exec_extension("pixi")
+            if candidate.is_dir() and executable_candidate.is_file():
+                pixi_bin_path = candidate
+                break
+
+        if pixi_bin_path is not None:
+            os.environ["PIXI_BIN_DIR"] = str(pixi_bin_path)
+            pixi_bin_dir = os.environ["PIXI_BIN_DIR"]
+
+    if pixi_bin_dir is None and pixi_bin_path is None:
         raise ValueError(
-            "PIXI_BIN_DIR environment variable is not set. "
-            "Please set it to the directory containing the Pixi executable."
+            "Could not determine Pixi binary location. Set PIXI_BIN_DIR or run "
+            "'pixi run download-artifacts --repo pixi'."
         )
 
-    pixi_bin_path = Path(pixi_bin_dir)
-    if not pixi_bin_path.is_dir():
+    if pixi_bin_path is None or not pixi_bin_path.is_dir():
         raise ValueError(
             f"PIXI_BIN_DIR points to '{pixi_bin_dir}' which is not a valid directory. "
             "Please set it to a directory that exists and contains the Pixi executable."
@@ -116,7 +197,10 @@ def pixi() -> Path:
     pixi_executable = pixi_bin_path / exec_extension("pixi")
 
     if not pixi_executable.is_file():
-        raise FileNotFoundError(f"Pixi executable not found at '{pixi_executable}'.")
+        raise FileNotFoundError(
+            f"Pixi executable not found at '{pixi_executable}'. Set PIXI_BIN_DIR or run "
+            "'pixi run download-artifacts --repo pixi'."
+        )
 
     return pixi_executable
 
@@ -130,24 +214,10 @@ def build_backends(load_dotenv: None) -> None:
     to the build backends.
 
     Requires the BUILD_BACKENDS_BIN_DIR environment variable to be set.
-    Locally, this is typically done via the .env file.
+    Falls back to binaries downloaded into the artifacts directory.
     """
     build_backends_dir = os.getenv("BUILD_BACKENDS_BIN_DIR")
 
-    if not build_backends_dir:
-        raise ValueError(
-            "BUILD_BACKENDS_BIN_DIR environment variable is not set. "
-            "Please set it to a directory that contains build backend definitions."
-        )
-
-    build_backends_path = Path(build_backends_dir)
-    if not build_backends_path.is_dir():
-        raise ValueError(
-            f"BUILD_BACKENDS_BIN_DIR points to '{build_backends_dir}' which is not a valid directory. "
-            "Please set it to a directory that exists and contains build backend definitions."
-        )
-
-    # Define the build backends
     backends = [
         "pixi-build-cmake",
         "pixi-build-python",
@@ -155,12 +225,47 @@ def build_backends(load_dotenv: None) -> None:
         "pixi-build-rust",
     ]
 
+    if build_backends_dir:
+        build_backends_path = Path(build_backends_dir)
+    else:
+        project_root = repo_root()
+        candidates = [
+            project_root / "artifacts",
+            project_root / "artifacts" / "pixi-build-backends",
+        ]
+        build_backends_path = None
+        for candidate in candidates:
+            if not candidate.is_dir():
+                continue
+            if all((candidate / exec_extension(backend)).is_file() for backend in backends):
+                build_backends_path = candidate
+                break
+
+        if build_backends_path is not None:
+            os.environ["BUILD_BACKENDS_BIN_DIR"] = str(build_backends_path)
+            build_backends_dir = os.environ["BUILD_BACKENDS_BIN_DIR"]
+
+    if build_backends_dir is None and build_backends_path is None:
+        raise ValueError(
+            "Could not determine build backend locations. Set BUILD_BACKENDS_BIN_DIR or run "
+            "'pixi run download-artifacts --repo pixi-build-backends'."
+        )
+
+    if build_backends_path is None or not build_backends_path.is_dir():
+        raise ValueError(
+            f"BUILD_BACKENDS_BIN_DIR points to '{build_backends_dir}' which is not a valid directory. "
+            "Please set it to a directory that exists and contains build backend definitions."
+        )
+
     # Build the override string in the format: tool_name=/path/to/executable::tool_name2=...
     override_parts = []
     for backend in backends:
         backend_path = build_backends_path / exec_extension(backend)
         if not backend_path.is_file():
-            raise FileNotFoundError(f"'{backend}' not found at '{backend_path}'.")
+            raise FileNotFoundError(
+                f"'{backend}' not found at '{backend_path}'. Set BUILD_BACKENDS_BIN_DIR "
+                "or run 'pixi run download-artifacts --repo pixi-build-backends'."
+            )
 
         override_parts.append(f"{backend}={backend_path}")
 

--- a/tests/integration_python/conftest.py
+++ b/tests/integration_python/conftest.py
@@ -2,6 +2,7 @@ import json
 import os
 import shutil
 from pathlib import Path
+from typing import Any, cast
 
 import dotenv
 import pytest
@@ -88,11 +89,19 @@ def _load_artifact_metadata() -> dict[str, object]:
         return {}
 
     try:
-        return json.loads(metadata_file.read_text(encoding="utf-8"))
+        data: Any = json.loads(metadata_file.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
         raise RuntimeError(
             f"Artifact metadata file at {metadata_file} is not valid JSON. Re-run 'pixi run download-artifacts'."
         ) from exc
+
+    if not isinstance(data, dict):
+        raise RuntimeError(
+            f"Artifact metadata file at {metadata_file} must contain a JSON object. "
+            "Re-run 'pixi run download-artifacts'."
+        )
+
+    return cast(dict[str, object], data)
 
 
 def _validate_artifact_sources() -> None:


### PR DESCRIPTION
This was created with codex, so take that into account when reading. Basically it adds the functionality to use the `.env.ci` or `.env` file to set the PR number and that it downloads those artifacts locally, one can still set the `_BIN_DIR` to override this completely.

I've also added a check that if you run the tests that it checks you are not depending on the wrong artifacts. This is done by using a metadata file when downloading the artifacts, this can then be cross-referenced during testing. Additionally, I've update the artifacts script to download all artifacts by default if you do not specify the repo.

The `README` has been updated to reflect these changes. I've tested out most combinations locally PR, and BIN. No Pr's. Or both and it seems to work well.
