### PR TITLE
feat: bump rattler-build backend version in log-example

### DIFF
--- a/tests/data/pixi_build/log-example/working/pixi.lock
+++ b/tests/data/pixi_build/log-example/working/pixi.lock
@@ -23,8 +23,9 @@ packages:
   build: h0dc7051_0
   subdir: osx-64
   input:
-    hash: 8d1d52341921800e7ab8a779709ab7deec64a6281480dfda121b9e6aaea71c4d
+    hash: 18bb1687ed91f73a966ea7214c5497f76de790fc22b918b35057fb0020124871
     globs:
+    - recipe.yaml
     - variants.yaml
 - conda: .
   name: simple-app
@@ -32,8 +33,9 @@ packages:
   build: h60d57d3_0
   subdir: osx-arm64
   input:
-    hash: 8d1d52341921800e7ab8a779709ab7deec64a6281480dfda121b9e6aaea71c4d
+    hash: 18bb1687ed91f73a966ea7214c5497f76de790fc22b918b35057fb0020124871
     globs:
+    - recipe.yaml
     - variants.yaml
 - conda: .
   name: simple-app
@@ -41,8 +43,9 @@ packages:
   build: h9490d1a_0
   subdir: win-64
   input:
-    hash: 8d1d52341921800e7ab8a779709ab7deec64a6281480dfda121b9e6aaea71c4d
+    hash: 18bb1687ed91f73a966ea7214c5497f76de790fc22b918b35057fb0020124871
     globs:
+    - recipe.yaml
     - variants.yaml
 - conda: .
   name: simple-app
@@ -50,6 +53,7 @@ packages:
   build: hb0f4dca_0
   subdir: linux-64
   input:
-    hash: 8d1d52341921800e7ab8a779709ab7deec64a6281480dfda121b9e6aaea71c4d
+    hash: 18bb1687ed91f73a966ea7214c5497f76de790fc22b918b35057fb0020124871
     globs:
+    - recipe.yaml
     - variants.yaml

--- a/tests/data/pixi_build/log-example/working/pixi.toml
+++ b/tests/data/pixi_build/log-example/working/pixi.toml
@@ -19,4 +19,4 @@ channels = [
   "https://prefix.dev/conda-forge",
 ]
 name = "pixi-build-rattler-build"
-version = "*"
+version = "0.3.*"


### PR DESCRIPTION
For some reason, globs that are used here:
https://github.com/prefix-dev/pixi-build-backends/actions/runs/18565469796/job/52925897952

are the oldstylish, which triggers the same issue: https://github.com/prefix-dev/pixi/issues/4722