### PR TITLE
fix: subdir is `None`

### DIFF
--- a/tests/integration_python/test_specified_build_source/test_git.py
+++ b/tests/integration_python/test_specified_build_source/test_git.py
@@ -223,7 +223,7 @@ def test_git_path_lock_branch_records_branch_metadata(
     assert {entry.get("branch") for entry in entries} == {"other-feature"}
     assert {entry.get("rev") for entry in entries} == {local_cpp_git_repo.other_feature_rev}
     assert all("tag" not in entry for entry in entries)
-    assert {entry.get("subdir") for entry in entries} == {"."}
+    assert {entry.get("subdir") for entry in entries} == {None}
 
     verify_cli_command(
         [pixi, "install", "-v", "--manifest-path", tmp_pixi_workspace, "--locked"],
@@ -332,7 +332,7 @@ def test_git_path_lock_tag_records_tag_metadata(
     assert {entry.get("tag") for entry in entries} == {local_cpp_git_repo.tag}
     assert {entry.get("rev") for entry in entries} == {local_cpp_git_repo.main_rev}
     assert all("branch" not in entry for entry in entries)
-    assert {entry.get("subdir") for entry in entries} == {"."}
+    assert {entry.get("subdir") for entry in entries} == {None}
 
     verify_cli_command(
         [pixi, "install", "-v", "--manifest-path", tmp_pixi_workspace, "--locked"],


### PR DESCRIPTION
Fix for https://github.com/prefix-dev/pixi/pull/5269